### PR TITLE
Add go.mod and go.sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/agnivade/shimmer
+
+go 1.12
+
+require (
+	github.com/anthonynsimon/bild v0.0.0-20190311092716-e21126554192
+	golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/anthonynsimon/bild v0.0.0-20190311092716-e21126554192 h1:IRxECMMwkcdFpiBbVxguPzrAqyyO3n1LnWhtq1R43Gs=
+github.com/anthonynsimon/bild v0.0.0-20190311092716-e21126554192/go.mod h1:rY8HbNSqiIVRGquP67cbI8etkQGyCZzQ5Fkp0MdtXCQ=
+golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f h1:FO4MZ3N56GnxbqxGKqh+YTzUWQ2sDwtFQEZgLOxh9Jc=
+golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Thank you for introducing a great go-wasm example.

I faced a problem building the project in go1.12 environment, since the latest release of `github.com/anthonynsimon/bild` is as of year 2016 that does not include `imgio.JPEGEncoder` which is required for shimmer.

I had the go.mod file to use the latest commit of master (as of 20190311092716) so that shimmer can be built with the required function. And the specified commit can be replaced if newer version of `github.com/anthonynsimon/bild` is released.

Including go.sum and go.mod is recommended. https://github.com/golang/go/wiki/Modules#should-i-commit-my-gosum-file-as-well-as-my-gomod-file